### PR TITLE
EAHW-2135: Enable CORS on timecard api

### DIFF
--- a/helm/templates/ingress_timecard.yml
+++ b/helm/templates/ingress_timecard.yml
@@ -11,6 +11,8 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
     kubernetes.io/backend-protocol: "HTTPS"
+    ingress.kubernetes.io/enable-cors: "true"
+    ingress.kubernetes.io/cors-allow-origin: "https://{{ .Values.ui.host }}"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Enable CORS on timecard api by adding annotations on timecard ingress