### PR TITLE
EAHW 2428: Manual promote to prod pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -96,8 +96,7 @@ trigger:
     exclude:
       - promote
   branch:
-    #          - main #temporarily comment out for testing - to be reverted before PR
-    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+    - main
 
 steps:
   - name: deploy to dev
@@ -136,8 +135,7 @@ trigger:
     exclude:
       - promote
   branch:
-    #          - main #temporarily comment out for testing - to be reverted before PR
-    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+    - main
 
 steps:
   - name: deploy to test

--- a/.drone.yml
+++ b/.drone.yml
@@ -189,10 +189,6 @@ steps:
         from_secret: prod_kube_api_url
       kube_token:
         from_secret: prod_kube_token
-    when: #temporarily added for testing - to be reverted before PR
-      branch: #+
-        exclude: #+
-          - task/eahw-2428/manual-promote-to-prod-pipeline #+
 
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
       chart: ./helm
       values_files:
         - ./helm/values/dev-values.yaml
-        - ./helm/values/test-values.
+        - ./helm/values/test-values.yaml
         - ./helm/values/prod-values.yaml
 
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,8 +73,8 @@ steps:
       DRONE_TOKEN:
         from_secret: drone_token
     commands:
-      - LAST_BUILD=$(drone build ls --format '{{.Number}}' --branch "$DRONE_BRANCH" --status success --event push --limit 100 "$DRONE_REPO" | head -n 1)
-      - if [ $LAST_BUILD != $DRONE_BUILD_PARENT ]; then echo 'Could not promote as last build was not successful'; exit 1; fi
+      - chmod +x ./pipeline-scripts/check-build-promotion.sh
+      - ./pipeline-scripts/check-build-promotion.sh
 
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -145,6 +145,8 @@ trigger:
 steps:
   - name: deploy to test
     image: pelotech/drone-helm3
+    commands:
+      - exit 1
     settings:
       namespace: callisto-test
       mode: upgrade

--- a/.drone.yml
+++ b/.drone.yml
@@ -96,8 +96,8 @@ trigger:
     exclude:
       - promote
   branch:
-    - main #temporarily comment out for testing - to be reverted before PR
-#    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+#    - main #temporarily comment out for testing - to be reverted before PR
+    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
 steps:
   - name: deploy to dev
@@ -115,6 +115,9 @@ steps:
         from_secret: not_prod_kube_api_url
       kube_token:
         from_secret: dev_kube_token
+    when: #temporarily add for testing - to be reverted before PR
+      event: #+
+        - pull_request #+
 
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -96,7 +96,8 @@ trigger:
     exclude:
       - promote
   branch:
-    - main
+    #          - main #temporarily comment out for testing - to be reverted before PR
+    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
 steps:
   - name: deploy to dev
@@ -135,7 +136,8 @@ trigger:
     exclude:
       - promote
   branch:
-    - main
+    #          - main #temporarily comment out for testing - to be reverted before PR
+    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
 steps:
   - name: deploy to test

--- a/.drone.yml
+++ b/.drone.yml
@@ -204,8 +204,6 @@ trigger:
   status:
     - success
     - failure
-  event:
-    - push
 
 slack: &slack
   image: plugins/slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,21 +1,45 @@
 ---
 kind: pipeline
 type: kubernetes
-name: callisto-ingress
+name: lint-files
 
 platform:
   os: linux
   arch: amd64
 
+trigger:
+  event:
+    include:
+      - push
+      - pull_request
+    exclude:
+      - promote
+
 steps:
-  - name: lint helm files
+  - name: lint_helm_files
     image: pelotech/drone-helm3
     settings:
       mode: lint
       chart: ./helm
       values_files:
         - ./helm/values/dev-values.yaml
+        - ./helm/values/test-values.
+        - ./helm/values/prod-values.yaml
 
+
+---
+kind: pipeline
+type: kubernetes
+name: callisto-ingress
+
+platform:
+  os: linux
+  arch: amd64
+
+depends_on:
+  - lint-files
+
+steps:
   - name: deploy to dev
     image: pelotech/drone-helm3
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ steps:
       branch:
         exclude:
           #          - main #temporarily comment out for testing - to be reverted before PR
-          - $DRONE_BRANCH #temporarily use current branch for testing
+          - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
   - name: environment-check
     pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -96,8 +96,7 @@ trigger:
     exclude:
       - promote
   branch:
-#    - main #temporarily comment out for testing - to be reverted before PR
-    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+    - main
 
 steps:
   - name: deploy to dev
@@ -115,9 +114,6 @@ steps:
         from_secret: not_prod_kube_api_url
       kube_token:
         from_secret: dev_kube_token
-    when: #temporarily add for testing - to be reverted before PR
-      event: #+
-        - pull_request #+
 
 
 ---
@@ -139,14 +135,11 @@ trigger:
     exclude:
       - promote
   branch:
-#    - main #temporarily comment out for testing - to be reverted before PR
-    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+    - main
 
 steps:
   - name: deploy to test
     image: pelotech/drone-helm3
-    commands:
-      - exit 1
     settings:
       namespace: callisto-test
       mode: upgrade
@@ -196,6 +189,10 @@ steps:
         from_secret: prod_kube_api_url
       kube_token:
         from_secret: prod_kube_token
+    when: #temporarily added for testing - to be reverted before PR
+      branch: #+
+        exclude: #+
+          - task/eahw-2428/manual-promote-to-prod-pipeline #+
 
 
 ---
@@ -210,18 +207,23 @@ trigger:
   event:
     - push
 
+slack: &slack
+  image: plugins/slack
+  settings:
+    webhook:
+      from_secret: slack_webhook_url
+    channel: callisto-tech-notifications
+    username: Drone
+
 depends_on:
   - callisto-ingress-dev-deploy
   - callisto-ingress-test-deploy
+  - callisto-ingress-prod-deploy
 
 steps:
   - name: slack
-    image: plugins/slack
+    <<: *slack
     settings:
-      webhook:
-        from_secret: slack_webhook_url
-      channel: callisto-tech-notifications
-      username: Drone
       template: |
         {{#success build.status}}
           Build #{{ build.number }} succeeded! :tada:
@@ -232,3 +234,20 @@ steps:
         Repo: {{ repo.name }}
         Branch: <${DRONE_REPO_LINK}/commits/{{ build.branch }}|{{ build.branch }}>
         Author: {{ build.author }}
+    when:
+      event:
+        - push
+
+
+  - name: slack promotion
+    <<: *slack
+    settings:
+      template: >
+        {{#success build.status}}
+          :rocket: Successful *{{uppercasefirst build.deployTo}}* deployment for *{{repo.name}} build #{{build.number}}*.          
+        {{else}}
+          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for *{{repo.name}} <${DRONE_BUILD_LINK}| build #{{build.number}}*>.
+        {{/success}}
+    when:
+      event:
+        - promote

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,56 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
+name: promotion-check
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    - promote
+
+steps:
+  - name: branch-check
+    pull: if-not-exists
+    image: alpine:latest
+    commands:
+      - echo Cannot promote from non 'main' branch
+      - exit 1
+    when:
+      branch:
+        exclude:
+          #          - main #temporarily comment out for testing - to be reverted before PR
+          - $DRONE_BRANCH #temporarily use current branch for testing
+
+  - name: environment-check
+    pull: if-not-exists
+    image: alpine:latest
+    commands:
+      - echo Cannot promote to a non prod environment
+      - exit 1
+    when:
+      target:
+        exclude:
+          - production
+
+  - name: build-check
+    pull: if-not-exists
+    image: drone/cli:1.6.2-alpine
+    environment:
+      DRONE_BUILD_PARENT: ${DRONE_BUILD_PARENT}
+      DRONE_SERVER: https://drone-gh.acp.homeoffice.gov.uk
+      DRONE_TOKEN:
+        from_secret: drone_token
+    commands:
+      - LAST_BUILD=$(drone build ls --format '{{.Number}}' --branch "$DRONE_BRANCH" --status success --event push --limit 100 "$DRONE_REPO" | head -n 1)
+      - if [ $LAST_BUILD != $DRONE_BUILD_PARENT ]; then echo 'Could not promote as last build was not successful'; exit 1; fi
+
+
+---
+kind: pipeline
+type: kubernetes
 name: callisto-ingress-dev-deploy
 
 platform:
@@ -105,6 +155,43 @@ steps:
         from_secret: not_prod_kube_api_url
       kube_token:
         from_secret: test_kube_token
+
+
+---
+kind: pipeline
+type: kubernetes
+name: callisto-ingress-prod-deploy
+
+platform:
+  os: linux
+  arch: amd64
+
+depends_on:
+  - promotion-check
+
+trigger:
+  event:
+    - promote
+  target:
+    - production
+
+steps:
+  - name: deploy to prod
+    image: pelotech/drone-helm3
+    settings:
+      namespace: callisto-prod
+      mode: upgrade
+      chart: ./helm
+      values_files:
+        - ./helm/values/prod-values.yaml
+      release: callisto-ingress-nginx
+      kube_certificate:
+        from_secret: prod_kube_api_certificate
+      kube_api_server:
+        from_secret: prod_kube_api_url
+      kube_token:
+        from_secret: prod_kube_token
+
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: callisto-ingress
+name: callisto-ingress-dev-deploy
 
 platform:
   os: linux
@@ -70,17 +70,9 @@ platform:
   arch: amd64
 
 depends_on:
-  - callisto-ingress
+  - callisto-ingress-dev-deploy
 
 steps:
-  - name: lint helm files
-    image: pelotech/drone-helm3
-    settings:
-      mode: lint
-      chart: ./helm
-      values_files:
-        - ./helm/values/test-values.yaml
-
   - name: deploy to test
     image: pelotech/drone-helm3
     settings:
@@ -113,7 +105,8 @@ trigger:
     - push
 
 depends_on:
-  - callisto-ingress
+  - callisto-ingress-dev-deploy
+  - callisto-ingress-test-deploy
 
 steps:
   - name: slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,8 +50,7 @@ steps:
     when:
       branch:
         exclude:
-          #          - main #temporarily comment out for testing - to be reverted before PR
-          - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+          - main
 
   - name: environment-check
     pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,16 @@ platform:
 depends_on:
   - lint-files
 
+trigger:
+  event:
+    include:
+      - push
+    exclude:
+      - promote
+  branch:
+    - main #temporarily comment out for testing - to be reverted before PR
+#    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+
 steps:
   - name: deploy to dev
     image: pelotech/drone-helm3
@@ -55,9 +65,6 @@ steps:
         from_secret: not_prod_kube_api_url
       kube_token:
         from_secret: dev_kube_token
-    when:
-      event: push
-      branch: main
 
 
 ---
@@ -71,6 +78,16 @@ platform:
 
 depends_on:
   - callisto-ingress-dev-deploy
+
+trigger:
+  event:
+    include:
+      - push
+    exclude:
+      - promote
+  branch:
+    - main #temporarily comment out for testing - to be reverted before PR
+#    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
 steps:
   - name: deploy to test
@@ -88,9 +105,6 @@ steps:
         from_secret: not_prod_kube_api_url
       kube_token:
         from_secret: test_kube_token
-    when:
-      event: push
-      branch: main
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -239,7 +239,7 @@ steps:
         {{#success build.status}}
           :rocket: Successful *{{uppercasefirst build.deployTo}}* deployment for *{{repo.name}} build #{{build.number}}*.          
         {{else}}
-          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for *{{repo.name}} <${DRONE_BUILD_LINK}| build #{{build.number}}*>.
+          :zombie: Problem *{{uppercasefirst build.deployTo}}* deployment failed for *{{repo.name}} <${DRONE_BUILD_LINK}| build #{{build.number}}>*.
         {{/success}}
     when:
       event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -139,8 +139,8 @@ trigger:
     exclude:
       - promote
   branch:
-    - main #temporarily comment out for testing - to be reverted before PR
-#    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
+#    - main #temporarily comment out for testing - to be reverted before PR
+    - task/eahw-2428/manual-promote-to-prod-pipeline #temporarily use current branch for testing
 
 steps:
   - name: deploy to test

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ To get around this, you need to prevent Prettier from running in Helm files by a
   "editor.formatOnSave": false
 },
 ```
+
+## Considerations
+a `DRONE_TOKEN` is used in the drone yaml file to get access to execute drone cli commands. This token is tied to a specific user and stored in the drone secrets for this repo. If the user is removed from drone the `DRONE_TOKEN` must be replaced with someone else.

--- a/helm/templates/ingress_timecard.yml
+++ b/helm/templates/ingress_timecard.yml
@@ -17,7 +17,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.timecard.host }}
-      secretName: callisto-timecard-tls
+      secretName: {{ .Values.timecard.tls_secret_name }}
   rules:
     - host: {{ .Values.timecard.host }}
       http:

--- a/helm/values/dev-values.yaml
+++ b/helm/values/dev-values.yaml
@@ -11,6 +11,7 @@ timecard:
     name: callisto-timecard-restapi
     port: 9090
   host: timecard.dev.callisto-notprod.homeoffice.gov.uk
+  tls_secret_name: callisto-timecard-tls
 
 accruals:
   name: callisto-accruals-restapi

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -11,7 +11,7 @@ timecard:
     name: callisto-timecard-restapi
     port: 9090
   host: timecard.callisto.homeoffice.gov.uk
-  tls_secret_name: callisto-timecard-tls-7c4n6-2hm4n
+  tls_secret_name: callisto-timecard-tls-7c4n6-2hm4n #TODO: EAHW-2481
 
 accruals:
   name: callisto-accruals-restapi

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -1,0 +1,20 @@
+ui:
+  name: callisto
+  service:
+    name: callisto-web
+    port: 3000
+  host: web.callisto.homeoffice.gov.uk
+
+timecard:
+  name: callisto-timecard-restapi
+  service:
+    name: callisto-timecard-restapi
+    port: 9090
+  host: timecard.callisto.homeoffice.gov.uk
+
+accruals:
+  name: callisto-accruals-restapi
+  service:
+    name: callisto-accruals-restapi
+    port: 8080
+  host: accruals.callisto.homeoffice.gov.uk

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -11,7 +11,7 @@ timecard:
     name: callisto-timecard-restapi
     port: 9090
   host: timecard.callisto.homeoffice.gov.uk
-  tls_secret_name: callisto-timecard-tls-7c4n6
+  tls_secret_name: callisto-timecard-tls-7c4n6-2hm4n
 
 accruals:
   name: callisto-accruals-restapi

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -11,6 +11,7 @@ timecard:
     name: callisto-timecard-restapi
     port: 9090
   host: timecard.callisto.homeoffice.gov.uk
+  tls_secret_name: callisto-timecard-tls-7c4n6
 
 accruals:
   name: callisto-accruals-restapi

--- a/helm/values/test-values.yaml
+++ b/helm/values/test-values.yaml
@@ -11,6 +11,7 @@ timecard:
     name: callisto-timecard-restapi
     port: 9090
   host: timecard.test.callisto-notprod.homeoffice.gov.uk
+  tls_secret_name: callisto-timecard-tls
 
 accruals:
   name: callisto-accruals-restapi

--- a/pipeline-scripts/check-build-promotion.sh
+++ b/pipeline-scripts/check-build-promotion.sh
@@ -1,8 +1,8 @@
-LAST_BUILD=$(
+LAST_SUCCESSFUL_BUILD=$(
   drone build ls --format '{{.Number}}' --branch "$DRONE_BRANCH" --status success \
   --limit 100 "$DRONE_REPO" | head -n 1
 )
-if [ $LAST_BUILD != $DRONE_BUILD_PARENT ]; then
-  echo 'Could not promote as last build: ' $LAST_BUILD ' was not successful';
+if [ $LAST_SUCCESSFUL_BUILD != $DRONE_BUILD_PARENT ]; then
+  echo 'Could not promote as build: ' $DRONE_BUILD_PARENT ' was not successful';
   exit 1;
 fi

--- a/pipeline-scripts/check-build-promotion.sh
+++ b/pipeline-scripts/check-build-promotion.sh
@@ -1,6 +1,6 @@
 LAST_BUILD=$(
   drone build ls --format '{{.Number}}' --branch "$DRONE_BRANCH" --status success \
-  --event push --limit 100 "$DRONE_REPO" | head -n 1
+  --limit 100 "$DRONE_REPO" | head -n 1
 )
 if [ $LAST_BUILD != $DRONE_BUILD_PARENT ]; then
   echo 'Could not promote as last build: ' $LAST_BUILD ' was not successful';

--- a/pipeline-scripts/check-build-promotion.sh
+++ b/pipeline-scripts/check-build-promotion.sh
@@ -1,0 +1,8 @@
+LAST_BUILD=$(
+  drone build ls --format '{{.Number}}' --branch "$DRONE_BRANCH" --status success \
+  --event push --limit 100 "$DRONE_REPO" | head -n 1
+)
+if [ $LAST_BUILD != $DRONE_BUILD_PARENT ]; then
+  echo 'Could not promote as last build: ' $LAST_BUILD ' was not successful';
+  exit 1;
+fi


### PR DESCRIPTION
- This PR automates the test deployment to run straight after dev deploys successfully
- Allows manually promoting to prod only for successful drone builds
  - Ensures promotion is only done on main branch and for prod env
  - Uses drone cli to check the last succesful build for this branch is the one we're promoting (from the last 100 builds on the repo)
- Move linting to dedicated pipeline so that prod linting runs even when pipeline is excluded for the initial non-promotion drone build / branch build
- New prod values for accruals, tiemcard and web
- updated slack messages to stay consistent with Holly's one in the UI
- timecard tls secret name change happened due to ssl issues on ACP side, there is a new ticket to cover reverting this. See TODO comment in yaml.